### PR TITLE
Remove HTTPS redirection from frontend and backend

### DIFF
--- a/SampleApp/BackEnd/Program.cs
+++ b/SampleApp/BackEnd/Program.cs
@@ -25,8 +25,6 @@ if (app.Environment.IsDevelopment())
     app.MapScalarApiReference();
 }
 
-app.UseHttpsRedirection();
-
 var summaries = new[]
 {
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"

--- a/SampleApp/FrontEnd/Program.cs
+++ b/SampleApp/FrontEnd/Program.cs
@@ -21,7 +21,6 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
-app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRouting();
 app.MapBlazorHub();


### PR DESCRIPTION
The application was forcing all traffic to HTTPS, which was causing issues for the user on their Android device, particularly with deep links.

This change removes the `app.UseHttpsRedirection()` middleware from both the frontend and backend `Program.cs` files to prevent this redirection. 

Add Closing keywords